### PR TITLE
Add /Packages/ to .gitignore

### DIFF
--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -68,6 +68,7 @@ And we will add the following
 ```
 /Artifacts/
 /Documentation/
+/Packages/
 
 RecentCertificateData.json
 *.cert


### PR DESCRIPTION
/Packages/ contains build artifacts around 100Mb each that should be excluded from the git repository.